### PR TITLE
FIX: .WAV data always has 1 minute length written in header

### DIFF
--- a/bind/api.go
+++ b/bind/api.go
@@ -2,6 +2,8 @@
 package bind
 
 import (
+	"time"
+
 	"github.com/go-ontomix/ontomix/bind/hardware/null"
 	"github.com/go-ontomix/ontomix/bind/hardware/portaudio"
 	"github.com/go-ontomix/ontomix/bind/hardware/sdl"
@@ -33,6 +35,16 @@ func IsDirectOutput() bool {
 // SetMixNextOutFunc to stream mix out from ontomix
 func SetOutputCallback(fn sample.OutNextCallbackFunc) {
 	sample.SetOutputCallback(fn)
+}
+
+// OutputStart requires a known length
+func OutputStart(length time.Duration) {
+	switch useOutput {
+	case opt.OutputWAV:
+		wav.OutputStart(length)
+	case opt.OutputNull:
+	// do nothing
+	}
 }
 
 // OutputNext using the configured writer.

--- a/bind/spec/spec.go
+++ b/bind/spec/spec.go
@@ -1,6 +1,10 @@
 // Package spec specifies valid audio formats
 package spec
 
+import (
+	"time"
+)
+
 // Tz is the unit of measurement of samples-over-time, e.g. for 48000Hz playback there are 48,000 Tz in 1 second.
 type Tz uint64
 
@@ -9,6 +13,7 @@ type AudioSpec struct {
 	Freq     float64
 	Format   AudioFormat
 	Channels int
+	Length time.Duration
 }
 
 // Validate these specs

--- a/bind/wav/writer.go
+++ b/bind/wav/writer.go
@@ -16,8 +16,10 @@ import (
 
 func ConfigureOutput(s spec.AudioSpec) {
 	outputSpec = &s
-	writer = NewWriter(stdout, 1*time.Minute, FormatFromSpec(outputSpec))
-	// TODO: create a new writer to stdout
+}
+
+func OutputStart(length time.Duration) {
+	writer = NewWriter(stdout, FormatFromSpec(outputSpec), length)
 }
 
 func TeardownOutput() {
@@ -29,7 +31,7 @@ type Writer struct {
 	Format *Format
 }
 
-func NewWriter(w io.Writer, length time.Duration, format Format) (writer *Writer) {
+func NewWriter(w io.Writer, format Format, length time.Duration) (writer *Writer) {
 	dataSize := uint32(float64(length/time.Second)*float64(format.SampleRate)) * uint32(format.BlockAlign)
 	riffSize := 4 + 8 + 16 + 8 + dataSize
 	riffWriter := riff.NewWriter(w, []byte("WAVE"), riffSize)

--- a/demo/demo.go
+++ b/demo/demo.go
@@ -97,6 +97,7 @@ func main() {
 	//
 	if bind.IsDirectOutput() {
 		ontomix.Debug(true)
+		ontomix.OutputStart(t)
 		for p := time.Duration(0); p <= t; p += t / 4 {
 			ontomix.OutputContinueTo(p)
 		}

--- a/lib/mix/mix.go
+++ b/lib/mix/mix.go
@@ -113,6 +113,11 @@ func GetCycleDurationTz() spec.Tz {
 	return masterCycleDurTz
 }
 
+// OutputStart requires a known length
+func OutputStart(length time.Duration) {
+	bind.OutputStart(length)
+}
+
 // OutputContinueTo to  mix and output as []byte via stdout, up to a specified duration-since-start
 func OutputContinueTo(t time.Duration) {
 	deltaDur := t - outputToDur

--- a/lib/mix/mix_test.go
+++ b/lib/mix/mix_test.go
@@ -14,7 +14,7 @@ import (
 // Tests
 //
 
-func TestMixer_Base(t *testing.T) {
+func TestBase(t *testing.T) {
 	Configure(spec.AudioSpec{
 		Freq:     44100,
 		Format:   spec.AudioU16,
@@ -23,77 +23,89 @@ func TestMixer_Base(t *testing.T) {
 	assert.NotNil(t, Spec())
 }
 
-func TestMixer_RequiresProperAudioSpec(t *testing.T) {
+func TestRequiresProperAudioSpec(t *testing.T) {
 	assert.Panics(t, func() {
 		Configure(spec.AudioSpec{})
 	})
 }
 
-func TestMixer_Initialize(t *testing.T) {
+func TestInitialize(t *testing.T) {
 	// TODO: Test Mixer Initialize
 }
 
-func TestMixer_Debug(t *testing.T) {
+func TestDebug(t *testing.T) {
 	// TODO: Test Mixer Debug
 }
 
-func TestMixer_Debugf(t *testing.T) {
+func TestDebugf(t *testing.T) {
 	// TODO: Test Mixer debug.Printf
 }
 
-func TestMixer_Start(t *testing.T) {
+func TestStart(t *testing.T) {
 	// TODO: Test Mixer Start
 }
 
-func TestMixer_StartAt(t *testing.T) {
+func TestStartAt(t *testing.T) {
 	// TODO: Test Mixer StartAt
 }
 
-func TestMixer_GetStartTime(t *testing.T) {
+func TestGetStartTime(t *testing.T) {
 	// TODO: Test Mixer GetStartTime
 }
 
-func TestMixer_SetFire(t *testing.T) {
+func TestSetFire(t *testing.T) {
 	// TODO: Test Mixer SetFire
 }
 
-func TestMixer_SetSoundsPath(t *testing.T) {
+func TestSetSoundsPath(t *testing.T) {
 	// TODO: Test Mixer SetSoundsPath
 }
 
-func TestMixer_NextOut(t *testing.T) {
+func TestNextOut(t *testing.T) {
 	// TODO: Test Mixer NextOut
 }
 
-func TestMixer_Teardown(t *testing.T) {
+func TestTeardown(t *testing.T) {
 	// TODO: Test Mixer Teardown
 }
 
-func TestMixer_nextSample(t *testing.T) {
+func TestNextSample(t *testing.T) {
 	// TODO: Test Mixer nextSample
 }
 
-func TestMixer_sourceAtTz(t *testing.T) {
-	// TODO: Test Mixer sourceAt
-}
-
-func TestMixer_setSpec(t *testing.T) {
-	// TODO: Test Mixer setSpec
-}
-
-func TestMixer_getSpec(t *testing.T) {
-	// TODO: Test Mixer getSpec
-}
-
-func TestMixer_prepareSource(t *testing.T) {
-	// TODO: Test Mixer prepareSource
-}
-
-func TestMixer_mixCleanup(t *testing.T) {
+func TestOutputStart(t *testing.T) {
 	// TODO: Test
 }
 
-func TestMixer_mixSetSpec(t *testing.T) {
+func TestOutputContinueTo(t *testing.T) {
+	// TODO: Test
+}
+
+func TestOutputClose(t *testing.T) {
+	// TODO: Test
+}
+
+func TestSourceAtTz(t *testing.T) {
+	// TODO: Test Mixer sourceAt
+}
+
+func TestSetSpec(t *testing.T) {
+	// TODO: Test Mixer setSpec
+}
+
+func TestGetSpec(t *testing.T) {
+	// TODO: Test Mixer getSpec
+}
+
+func TestPrepareSource(t *testing.T) {
+	// TODO: Test Mixer prepareSource
+}
+
+func TestMixCleanup(t *testing.T) {
+	// TODO: Test
+}
+
+func TestMixSetSpec(t *testing.T) {
 	// TODO: Test success passing in a bind.AudioSpec
 	// TODO: Test sets the default mixCycleDurTz
 }
@@ -108,11 +120,11 @@ func TestSetCycleDuration(t *testing.T) {
 	SetCycleDuration(5 * time.Second)
 }
 
-func TestMixer_getSource(t *testing.T) {
+func TestGetSource(t *testing.T) {
 	// TODO: Test Mixer getSource
 }
 
-func TestMixer_mixCycle(t *testing.T) {
+func TestMixCycle(t *testing.T) {
 	// TODO: Test garbage collection of unused sources
 	// TODO: Test garbage collection of unused fires
 }

--- a/ontomix.go
+++ b/ontomix.go
@@ -249,6 +249,11 @@ func GetNowAt() time.Duration {
 	return mix.GetNowAt()
 }
 
+// OutputStart requires a known length
+func OutputStart(length time.Duration) {
+	mix.OutputStart(length)
+}
+
 // OutputContinueTo output as []byte via stdout, up to a specified duration-since-start
 func OutputContinueTo(t time.Duration) {
 	mix.OutputContinueTo(t)

--- a/ontomix_test.go
+++ b/ontomix_test.go
@@ -99,6 +99,18 @@ func TestGetNowAt(t *testing.T) {
 	// TODO
 }
 
+func TestOutputStart(t *testing.T) {
+	// TODO: Test
+}
+
+func TestOutputContinueTo(t *testing.T) {
+	// TODO: Test
+}
+
+func TestOutputClose(t *testing.T) {
+	// TODO: Test
+}
+
 func TestAudioCallback(t *testing.T) {
 	// TODO: Test API AudioCallback
 }


### PR DESCRIPTION
Closer #51